### PR TITLE
fix: use "catalog:" instead of "catalog:default" for default catalog

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -30,7 +30,7 @@ export async function addCommand(options: CatalogOptions) {
 
   const deps = pkgJson[depsName] ||= {}
   for (const dep of dependencies) {
-    deps[dep.name] = dep.catalogName ? (`catalog:${dep.catalogName}`) : dep.specifier || '^0.0.0'
+    deps[dep.name] = dep.catalogName ? (dep.catalogName === 'default' ? 'catalog:' : `catalog:${dep.catalogName}`) : dep.specifier || '^0.0.0'
     if (pkgJson[depNameOppsite]?.[dep.name])
       delete pkgJson[depNameOppsite][dep.name]
   }

--- a/test/add.test.ts
+++ b/test/add.test.ts
@@ -1,0 +1,234 @@
+import type { PackageJson } from 'pkg-types'
+import type { RawDep } from '../src/types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { addCommand } from '../src/commands/add'
+import { resolveConfig } from '../src/config'
+import { DEFAULT_CATALOG_OPTIONS } from '../src/constants'
+
+// Mock only the essential dependencies for the core logic
+vi.mock('../src/utils/workspace', () => ({
+  readPackageJSON: vi.fn(),
+  confirmWorkspaceChanges: vi.fn().mockImplementation(async (modifier) => {
+    await modifier() // Execute the modifier to test workspace changes
+  }),
+}))
+
+vi.mock('../src/utils/resolver', () => ({
+  resolveAdd: vi.fn(),
+}))
+
+vi.mock('../src/io/workspace', () => ({
+  ensureWorkspaceYAML: vi.fn().mockResolvedValue({
+    workspaceYaml: {
+      setPackage: vi.fn(),
+    },
+    workspaceYamlPath: 'pnpm-workspace.yaml',
+  }),
+  findWorkspaceRoot: vi.fn().mockResolvedValue('/test/workspace'),
+}))
+
+// Mock side effects that don't affect core logic
+vi.mock('../src/utils/process', () => ({
+  runPnpmInstall: vi.fn(),
+}))
+
+vi.mock('../src/pnpm-catalog-manager', () => ({
+  PnpmCatalogManager: vi.fn().mockImplementation(() => ({
+    getCwd: vi.fn().mockReturnValue('/test/cwd'),
+  })),
+}))
+
+vi.mock('@clack/prompts', () => ({
+  outro: vi.fn(),
+  log: { success: vi.fn() },
+}))
+
+describe('addCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Mock process.argv with default value
+    Object.defineProperty(process, 'argv', {
+      value: ['node', 'pncat', 'add', 'test-package'],
+      writable: true,
+    })
+  })
+
+  async function setupTest(packageJson: PackageJson, dependencies: RawDep[], isDev = false) {
+    const config = await resolveConfig({ ...DEFAULT_CATALOG_OPTIONS })
+    const mockReadPackageJSON = vi.mocked((await import('../src/utils/workspace')).readPackageJSON)
+    const mockResolveAdd = vi.mocked((await import('../src/utils/resolver')).resolveAdd)
+
+    mockReadPackageJSON.mockResolvedValue({
+      pkgJson: packageJson,
+      pkgPath: '/test/package.json',
+    })
+
+    mockResolveAdd.mockResolvedValue({
+      isDev,
+      dependencies,
+    })
+
+    return config
+  }
+
+  it('should generate "catalog:" for default catalog dependencies', async () => {
+    const packageJson: PackageJson = {
+      name: 'test-package',
+      dependencies: {},
+    }
+
+    const dependencies: RawDep[] = [{
+      name: 'eslint',
+      specifier: '^8.0.0',
+      catalogName: 'default',
+      source: 'dependencies',
+      catalog: false,
+      catalogable: true,
+    }]
+
+    const config = await setupTest(packageJson, dependencies)
+    await addCommand(config)
+
+    expect(packageJson.dependencies).toEqual({
+      eslint: 'catalog:',
+    })
+  })
+
+  it('should generate "catalog:named" for named catalog dependencies', async () => {
+    const packageJson: PackageJson = {
+      name: 'test-package',
+      dependencies: {},
+    }
+
+    const dependencies: RawDep[] = [{
+      name: 'vue',
+      specifier: '^3.0.0',
+      catalogName: 'frontend',
+      source: 'dependencies',
+      catalog: false,
+      catalogable: true,
+    }]
+
+    const config = await setupTest(packageJson, dependencies)
+    await addCommand(config)
+
+    expect(packageJson.dependencies).toEqual({
+      vue: 'catalog:frontend',
+    })
+  })
+
+  it('should handle multiple dependencies with different catalog types', async () => {
+    const packageJson: PackageJson = {
+      name: 'test-package',
+      dependencies: {},
+    }
+
+    const dependencies: RawDep[] = [
+      {
+        name: 'eslint',
+        specifier: '^8.0.0',
+        catalogName: 'default',
+        source: 'dependencies',
+        catalog: false,
+        catalogable: true,
+      },
+      {
+        name: 'vue',
+        specifier: '^3.0.0',
+        catalogName: 'frontend',
+        source: 'dependencies',
+        catalog: false,
+        catalogable: true,
+      },
+      {
+        name: 'lodash',
+        specifier: '^4.0.0',
+        catalogName: 'utils',
+        source: 'dependencies',
+        catalog: false,
+        catalogable: true,
+      },
+    ]
+
+    const config = await setupTest(packageJson, dependencies)
+    await addCommand(config)
+
+    expect(packageJson.dependencies).toEqual({
+      eslint: 'catalog:',
+      vue: 'catalog:frontend',
+      lodash: 'catalog:utils',
+    })
+  })
+
+  it('should handle dev dependencies with default catalog', async () => {
+    const packageJson: PackageJson = {
+      name: 'test-package',
+      devDependencies: {},
+    }
+
+    const dependencies: RawDep[] = [{
+      name: 'vitest',
+      specifier: '^1.0.0',
+      catalogName: 'default',
+      source: 'devDependencies',
+      catalog: false,
+      catalogable: true,
+    }]
+
+    const config = await setupTest(packageJson, dependencies, true)
+    await addCommand(config)
+
+    expect(packageJson.devDependencies).toEqual({
+      vitest: 'catalog:',
+    })
+  })
+
+  it('should handle non-catalog dependencies', async () => {
+    const packageJson: PackageJson = {
+      name: 'test-package',
+      dependencies: {},
+    }
+
+    const dependencies: RawDep[] = [{
+      name: 'some-package',
+      specifier: '^2.0.0',
+      source: 'dependencies',
+      catalog: false,
+      catalogable: false,
+    } as RawDep]
+
+    const config = await setupTest(packageJson, dependencies)
+    await addCommand(config)
+
+    expect(packageJson.dependencies).toEqual({
+      'some-package': '^2.0.0',
+    })
+  })
+
+  it('should move dependencies between dep types when adding', async () => {
+    const packageJson: PackageJson = {
+      name: 'test-package',
+      dependencies: {},
+      devDependencies: {
+        eslint: '^7.0.0',
+      },
+    }
+
+    const dependencies: RawDep[] = [{
+      name: 'eslint',
+      specifier: '^8.0.0',
+      catalogName: 'default',
+      source: 'dependencies',
+      catalog: false,
+      catalogable: true,
+    }]
+
+    const config = await setupTest(packageJson, dependencies)
+    await addCommand(config)
+
+    expect(packageJson.dependencies).toEqual({
+      eslint: 'catalog:',
+    })
+    expect(packageJson.devDependencies).toEqual({})
+  })
+})


### PR DESCRIPTION
## Bug: Default catalog generates `catalog:default` instead of `catalog:` in package.json

Hi, first of all, thank you for this very convenient CLI tool! It has saved me from manually replacing version specifiers across a large monorepo. However, I may have come across some unintended behavior, so I wanted to let you know:

### Description

When adding dependencies to the default catalog using pncat, the generated package.json reference uses `"catalog:default"` instead of the correct(better?) pnpm format `"catalog:"`. <cite/>

### Expected Behavior

According to pnpm's catalog specification, the default catalog should use the shorter `"catalog:"` syntax without specifying "default".

### Actual Behavior

When adding a dependency that gets assigned to the default catalog, pncat generates:
```json
"eslint": "catalog:default"
```

Instead of the expected:
```json
"eslint": "catalog:"
```

<img width="1176" height="1216" alt="image" src="https://github.com/user-attachments/assets/651379d4-1a74-4d56-be03-31d59f4e3a9b" />


### Root Cause

The issue occurs in the `addCommand` function where dependencies with a `catalogName` are formatted as `catalog:${dep.catalogName}`. When the catalog name is "default", this results in `"catalog:default"` instead of handling the default case specially.

### Inconsistency in Codebase

This appears to be an inconsistency where the workspace YAML generation correctly handles the default catalog format (placing entries under `catalog` section rather than `catalogs.default`), but the package.json reference generation doesn't apply the same logic.

### Proposed Solution

The fix should be in the `addCommand` function to handle the default catalog case specially:

```typescript
deps[dep.name] = dep.catalogName === 'default' ? 'catalog:' : `catalog:${dep.catalogName}`
```

This would match pnpm's standard where the default catalog uses `catalog:` while named catalogs use `catalog:name`.
