### PR TITLE
fix: use "catalog:" instead of "catalog:default" also in detect and migrate

### DIFF
--- a/src/utils/render.ts
+++ b/src/utils/render.ts
@@ -51,8 +51,8 @@ export function renderChanges(deps: RawDep[], updatedPackages: Record<string, Pa
       const depName = dep.name.padEnd(maxDepNameWidth)
       const depType = DEPENDENCIES_TYPE_SHORT_MAP[dep.source].padEnd(maxDepTypeWidth)
       const depSpecifier = (dep.specifier || '').padStart(maxSpecifierWidth)
-      const catalogName = dep.catalogName.padEnd(maxCatalogWidth)
-      lines.push(`  ${depName} ${c.dim(depType)} ${c.red(depSpecifier)}  ${c.dim('→')}  catalog:${c.reset(c.green(`${catalogName}`))}`)
+      const catalogRef = (dep.catalogName === 'default' ? '' : dep.catalogName).padEnd(maxCatalogWidth)
+      lines.push(`  ${depName} ${c.dim(depType)} ${c.red(depSpecifier)}  ${c.dim('→')}  catalog:${c.reset(c.green(catalogRef))}`)
     }
     lines.push('')
   }

--- a/src/utils/resolver.ts
+++ b/src/utils/resolver.ts
@@ -153,7 +153,7 @@ export async function resolveMigrate(context: ResolveContext): Promise<ResolveRe
       updatedPackages.set(pkg.name, structuredClone(pkg))
 
     const pkgJson = updatedPackages.get(pkg.name)!
-    pkgJson.raw[dep.source][dep.name] = `catalog:${dep.catalogName}`
+    pkgJson.raw[dep.source][dep.name] = dep.catalogName === 'default' ? 'catalog:' : `catalog:${dep.catalogName}`
   }
 
   for (const pkg of packages) {

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -1,0 +1,128 @@
+import type { PackageJsonMeta, RawDep } from '../src/types'
+import { describe, expect, it } from 'vitest'
+import { renderChanges } from '../src/utils/render'
+
+describe('renderChanges', () => {
+  it('should render "catalog:" for default catalog dependencies', () => {
+    const deps: RawDep[] = [
+      {
+        name: 'eslint',
+        specifier: '^8.0.0',
+        catalogName: 'default',
+        source: 'devDependencies',
+        catalog: false,
+        catalogable: true,
+      },
+    ]
+
+    const updatedPackages: Record<string, PackageJsonMeta> = {
+      'test-package': {
+        name: 'test-package',
+        relative: './package.json',
+        filepath: '/test/package.json',
+        raw: { name: 'test-package' },
+        deps: [deps[0]],
+        type: 'package.json',
+        private: false,
+      },
+    }
+
+    const result = renderChanges(deps, updatedPackages)
+
+    expect(result).toContain('eslint')
+    expect(result).toContain('→')
+    expect(result).toContain('catalog:')
+    expect(result).not.toContain('default')
+  })
+
+  it('should render "catalog:named" for named catalog dependencies', () => {
+    const deps: RawDep[] = [
+      {
+        name: 'vue',
+        specifier: '^3.0.0',
+        catalogName: 'frontend',
+        source: 'dependencies',
+        catalog: false,
+        catalogable: true,
+      },
+    ]
+
+    const updatedPackages: Record<string, PackageJsonMeta> = {
+      'test-package': {
+        name: 'test-package',
+        relative: './package.json',
+        filepath: '/test/package.json',
+        raw: { name: 'test-package' },
+        deps: [deps[0]],
+        type: 'package.json',
+        private: false,
+      },
+    }
+
+    const result = renderChanges(deps, updatedPackages)
+
+    expect(result).toContain('vue')
+    expect(result).toContain('→')
+    expect(result).toContain('catalog:')
+    expect(result).toContain('frontend')
+  })
+
+  it('should handle mixed catalog types correctly', () => {
+    const deps: RawDep[] = [
+      {
+        name: 'eslint',
+        specifier: '^8.0.0',
+        catalogName: 'default',
+        source: 'devDependencies',
+        catalog: false,
+        catalogable: true,
+      },
+      {
+        name: 'vue',
+        specifier: '^3.0.0',
+        catalogName: 'frontend',
+        source: 'dependencies',
+        catalog: false,
+        catalogable: true,
+      },
+      {
+        name: 'lodash',
+        specifier: '^4.0.0',
+        catalogName: 'utils',
+        source: 'dependencies',
+        catalog: false,
+        catalogable: true,
+      },
+    ]
+
+    const updatedPackages: Record<string, PackageJsonMeta> = {
+      'test-package': {
+        name: 'test-package',
+        relative: './package.json',
+        filepath: '/test/package.json',
+        raw: { name: 'test-package' },
+        deps,
+        type: 'package.json',
+        private: false,
+      },
+    }
+
+    const result = renderChanges(deps, updatedPackages)
+
+    // Check that default catalog shows as "catalog:"
+    expect(result).toContain('eslint')
+    expect(result).toContain('→')
+    expect(result).toContain('catalog:')
+    // Check that named catalogs show correctly
+    expect(result).toContain('catalog:')
+    expect(result).toContain('frontend')
+    expect(result).toContain('utils')
+    // Ensure no "catalog:default" appears
+    expect(result).not.toContain('default')
+  })
+
+  it('should return empty string when no dependencies', () => {
+    const result = renderChanges([], {})
+    expect(result).toBe('')
+  })
+})

--- a/test/resolver.test.ts
+++ b/test/resolver.test.ts
@@ -1,20 +1,326 @@
-import type { RawDep } from '../src/types'
-import { expect, it } from 'vitest'
-import { resolveConflict } from '../src/utils/resolver'
+import type { PackageJsonMeta, RawDep } from '../src/types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { resolveConflict, resolveMigrate } from '../src/utils/resolver'
+
 import { createDep } from './_utils'
 
-it('should select the latest version', async () => {
-  const dependencies = new Map<string, Map<string, RawDep[]>>()
-  dependencies.set('vue', new Map())
-  dependencies.get('vue')!.set(
-    'frontend',
-    [
-      createDep<RawDep>('vue', '1.0.0'),
-      createDep<RawDep>('vue', '3.0.0'),
-      createDep<RawDep>('vue', '2.0.0'),
-    ],
-  )
-  await resolveConflict(dependencies, { yes: true })
-  expect(dependencies.get('vue')?.get('frontend')?.length).toBe(1)
-  expect(dependencies.get('vue')?.get('frontend')?.[0].specifier).toBe('3.0.0')
+// Mock the PnpmCatalogManager
+const mockPnpmCatalogManager = {
+  loadPackages: vi.fn(),
+  resolveDep: vi.fn(),
+}
+
+describe('resolveConflict', () => {
+  it('should select the latest version', async () => {
+    const dependencies = new Map<string, Map<string, RawDep[]>>()
+    dependencies.set('vue', new Map())
+    dependencies.get('vue')!.set(
+      'frontend',
+      [
+        createDep<RawDep>('vue', '1.0.0'),
+        createDep<RawDep>('vue', '3.0.0'),
+        createDep<RawDep>('vue', '2.0.0'),
+      ],
+    )
+    await resolveConflict(dependencies, { yes: true })
+    expect(dependencies.get('vue')?.get('frontend')?.length).toBe(1)
+    expect(dependencies.get('vue')?.get('frontend')?.[0].specifier).toBe('3.0.0')
+  })
+})
+
+describe('resolveMigrate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should generate "catalog:" for default catalog in package.json', async () => {
+    const mockPackages: PackageJsonMeta[] = [
+      {
+        name: 'test-package',
+        type: 'package.json',
+        filepath: '/test/package.json',
+        relative: './package.json',
+        private: false,
+        deps: [
+          {
+            name: 'eslint',
+            specifier: '^8.0.0',
+            source: 'devDependencies',
+            catalog: false,
+            catalogable: true,
+            catalogName: 'default',
+          },
+        ],
+        raw: {
+          name: 'test-package',
+          devDependencies: {
+            eslint: '^8.0.0',
+          },
+        },
+      },
+    ]
+
+    const resolvedDep: RawDep = {
+      name: 'eslint',
+      specifier: '^8.0.0',
+      catalogName: 'default',
+      source: 'devDependencies',
+      catalog: false,
+      catalogable: true,
+      update: true,
+    }
+
+    mockPnpmCatalogManager.loadPackages.mockResolvedValue(mockPackages)
+    mockPnpmCatalogManager.resolveDep.mockReturnValue(resolvedDep)
+
+    const result = await resolveMigrate({
+      options: { yes: true },
+      pnpmCatalogManager: mockPnpmCatalogManager as any,
+    })
+
+    expect(result.updatedPackages).toBeDefined()
+    const updatedPkg = result.updatedPackages!['test-package']
+    expect(updatedPkg).toBeDefined()
+    expect(updatedPkg.raw.devDependencies?.eslint).toBe('catalog:')
+    expect(updatedPkg.raw.devDependencies?.eslint).not.toBe('catalog:default')
+  })
+
+  it('should generate "catalog:named" for named catalog in package.json', async () => {
+    const mockPackages: PackageJsonMeta[] = [
+      {
+        name: 'test-package',
+        type: 'package.json',
+        filepath: '/test/package.json',
+        relative: './package.json',
+        private: false,
+        deps: [
+          {
+            name: 'vue',
+            specifier: '^3.0.0',
+            source: 'dependencies',
+            catalog: false,
+            catalogable: true,
+            catalogName: 'frontend',
+          },
+        ],
+        raw: {
+          name: 'test-package',
+          dependencies: {
+            vue: '^3.0.0',
+          },
+        },
+      },
+    ]
+
+    const resolvedDep: RawDep = {
+      name: 'vue',
+      specifier: '^3.0.0',
+      catalogName: 'frontend',
+      source: 'dependencies',
+      catalog: false,
+      catalogable: true,
+      update: true,
+    }
+
+    mockPnpmCatalogManager.loadPackages.mockResolvedValue(mockPackages)
+    mockPnpmCatalogManager.resolveDep.mockReturnValue(resolvedDep)
+
+    const result = await resolveMigrate({
+      options: { yes: true },
+      pnpmCatalogManager: mockPnpmCatalogManager as any,
+    })
+
+    expect(result.updatedPackages).toBeDefined()
+    const updatedPkg = result.updatedPackages!['test-package']
+    expect(updatedPkg).toBeDefined()
+    expect(updatedPkg.raw.dependencies?.vue).toBe('catalog:frontend')
+  })
+
+  it('should handle multiple dependencies with mixed catalog types', async () => {
+    const mockPackages: PackageJsonMeta[] = [
+      {
+        name: 'test-package',
+        type: 'package.json',
+        filepath: '/test/package.json',
+        relative: './package.json',
+        private: false,
+        deps: [
+          {
+            name: 'eslint',
+            specifier: '^8.0.0',
+            source: 'devDependencies',
+            catalog: false,
+            catalogable: true,
+            catalogName: 'default',
+          },
+          {
+            name: 'vue',
+            specifier: '^3.0.0',
+            source: 'dependencies',
+            catalog: false,
+            catalogable: true,
+            catalogName: 'frontend',
+          },
+          {
+            name: 'lodash',
+            specifier: '^4.0.0',
+            source: 'dependencies',
+            catalog: false,
+            catalogable: true,
+            catalogName: 'utils',
+          },
+        ],
+        raw: {
+          name: 'test-package',
+          dependencies: {
+            vue: '^3.0.0',
+            lodash: '^4.0.0',
+          },
+          devDependencies: {
+            eslint: '^8.0.0',
+          },
+        },
+      },
+    ]
+
+    const resolvedDeps = [
+      {
+        name: 'eslint',
+        specifier: '^8.0.0',
+        catalogName: 'default',
+        source: 'devDependencies',
+        catalog: false,
+        catalogable: true,
+        update: true,
+      },
+      {
+        name: 'vue',
+        specifier: '^3.0.0',
+        catalogName: 'frontend',
+        source: 'dependencies',
+        catalog: false,
+        catalogable: true,
+        update: true,
+      },
+      {
+        name: 'lodash',
+        specifier: '^4.0.0',
+        catalogName: 'utils',
+        source: 'dependencies',
+        catalog: false,
+        catalogable: true,
+        update: true,
+      },
+    ]
+
+    mockPnpmCatalogManager.loadPackages.mockResolvedValue(mockPackages)
+    mockPnpmCatalogManager.resolveDep
+      .mockReturnValueOnce(resolvedDeps[0])
+      .mockReturnValueOnce(resolvedDeps[1])
+      .mockReturnValueOnce(resolvedDeps[2])
+
+    const result = await resolveMigrate({
+      options: { yes: true },
+      pnpmCatalogManager: mockPnpmCatalogManager as any,
+    })
+
+    expect(result.updatedPackages).toBeDefined()
+    const updatedPkg = result.updatedPackages!['test-package']
+    expect(updatedPkg).toBeDefined()
+
+    // Check that default catalog generates "catalog:"
+    expect(updatedPkg.raw.devDependencies?.eslint).toBe('catalog:')
+    expect(updatedPkg.raw.devDependencies?.eslint).not.toBe('catalog:default')
+
+    // Check that named catalogs generate correctly
+    expect(updatedPkg.raw.dependencies?.vue).toBe('catalog:frontend')
+    expect(updatedPkg.raw.dependencies?.lodash).toBe('catalog:utils')
+  })
+
+  it('should skip non-catalogable dependencies', async () => {
+    const mockPackages: PackageJsonMeta[] = [
+      {
+        name: 'test-package',
+        type: 'package.json',
+        filepath: '/test/package.json',
+        relative: './package.json',
+        private: false,
+        deps: [
+          {
+            name: 'some-package',
+            specifier: '^1.0.0',
+            source: 'dependencies',
+            catalog: false,
+            catalogable: false, // Not catalogable
+            catalogName: 'default',
+          },
+        ],
+        raw: {
+          name: 'test-package',
+          dependencies: {
+            'some-package': '^1.0.0',
+          },
+        },
+      },
+    ]
+
+    mockPnpmCatalogManager.loadPackages.mockResolvedValue(mockPackages)
+
+    const result = await resolveMigrate({
+      options: { yes: true },
+      pnpmCatalogManager: mockPnpmCatalogManager as any,
+    })
+
+    // Should not update any packages since dependency is not catalogable
+    expect(Object.keys(result.updatedPackages || {})).toHaveLength(0)
+  })
+
+  it('should skip dependencies that do not need updates', async () => {
+    const mockPackages: PackageJsonMeta[] = [
+      {
+        name: 'test-package',
+        type: 'package.json',
+        filepath: '/test/package.json',
+        relative: './package.json',
+        private: false,
+        deps: [
+          {
+            name: 'eslint',
+            specifier: '^8.0.0',
+            source: 'devDependencies',
+            catalog: false,
+            catalogable: true,
+            catalogName: 'default',
+          },
+        ],
+        raw: {
+          name: 'test-package',
+          devDependencies: {
+            eslint: '^8.0.0',
+          },
+        },
+      },
+    ]
+
+    const resolvedDep: RawDep = {
+      name: 'eslint',
+      specifier: '^8.0.0',
+      catalogName: 'default',
+      source: 'devDependencies',
+      catalog: false,
+      catalogable: true,
+      update: false, // No update needed
+    }
+
+    mockPnpmCatalogManager.loadPackages.mockResolvedValue(mockPackages)
+    mockPnpmCatalogManager.resolveDep.mockReturnValue(resolvedDep)
+
+    const result = await resolveMigrate({
+      options: { yes: true },
+      pnpmCatalogManager: mockPnpmCatalogManager as any,
+    })
+
+    // Should not update any packages since dependency doesn't need update
+    expect(Object.keys(result.updatedPackages || {})).toHaveLength(0)
+  })
 })


### PR DESCRIPTION
Even after merging #3, `pncat detect` and `pncat migrate` still output `catalog:default` instead of `catalog:`.
It turns out that the fix in #3 was incomplete—sorry for not verifying the command behaviour against the built binary.

This PR should resolve the remaining issues and adds additional test cases.

I also manually verified it with the following configuration in the pncat repository after running `pncat revert`:

<img width="1245" height="1138" alt="image" src="https://github.com/user-attachments/assets/620f3d70-9a54-48d4-a3bf-2a4aa19a250a" />

<img width="406" height="669" alt="image" src="https://github.com/user-attachments/assets/46a99024-f06f-4708-96b7-6c36a6a7f303" />

<img width="422" height="975" alt="image" src="https://github.com/user-attachments/assets/a034a84e-cdc6-4414-bab6-ced1277af39f" />

<img width="1228" height="176" alt="image" src="https://github.com/user-attachments/assets/235fc858-bd36-4211-9fe0-54dd1af87634" />
